### PR TITLE
Speedup encoding by memoizing sRGBtoLinear

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -120,8 +120,8 @@ func multiplyBasisFunction(rgba *image.Image, factors []float64, xComponents int
 
 	yvalues := make([][]float64, yComponents)
 	for yComponent := 0; yComponent < yComponents; yComponent++ {
-		yvalues[yComponent] = make([]float64, width)
-		for y := 0; y < width; y++ {
+		yvalues[yComponent] = make([]float64, height)
+		for y := 0; y < height; y++ {
 			yvalues[yComponent][y] = math.Cos(math.Pi * float64(yComponent) * float64(y) / float64(width))
 		}
 	}

--- a/encode.go
+++ b/encode.go
@@ -122,7 +122,7 @@ func multiplyBasisFunction(rgba *image.Image, factors []float64, xComponents int
 	for yComponent := 0; yComponent < yComponents; yComponent++ {
 		yvalues[yComponent] = make([]float64, height)
 		for y := 0; y < height; y++ {
-			yvalues[yComponent][y] = math.Cos(math.Pi * float64(yComponent) * float64(y) / float64(width))
+			yvalues[yComponent][y] = math.Cos(math.Pi * float64(yComponent) * float64(y) / float64(height))
 		}
 	}
 


### PR DESCRIPTION
This trades encoder performance for memory, so it
might not be desirable in all cases